### PR TITLE
improve user experience and fix build

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Options:
 
 Default option is `--all`.
 
+Exit by typing `exit` or `lin exit` in a session.
+
 ## Contributing
 
 Please refer to [contributing.md](https://github.com/pacifiquem/lin/blob/main/contributing.md) for contribution guide.

--- a/src/commands.c
+++ b/src/commands.c
@@ -44,6 +44,8 @@ int execute_command(const char *command, Args lin_args) {
     char output[MAX_OUTPUT_SIZE];
     char aggregated_output[MAX_OUTPUT_SIZE * 24]; // maximum aggregated output we can store
 
+    if (strcmp(command, "exit") == 0) exit(0);
+
     // Open a pipe to the command
     fp = popen(command, "r");
     if (fp == NULL) {

--- a/src/commands.c
+++ b/src/commands.c
@@ -31,6 +31,7 @@ void save_commands_and_output(const char *output, const char *command, const Arg
     {
         fprintf(file, "Command: \n\t%s \nOutput:\n\t%s", command, output); // Save both command and output with newline
     }
+    fprintf(file, "%s\n", "------------------");
 
     fclose(file);
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <readline/readline.h>
 #include <readline/history.h>
 


### PR DESCRIPTION
1. Each command and or output is now delimited when written to file
2. `lin` will now exit when the user types `exit` in a session
3. include `string.h` in `main.c` to fix build (I couldn't build this on macos)